### PR TITLE
Remove the drawStar method, use extras instead

### DIFF
--- a/src/SmoothGraphics.ts
+++ b/src/SmoothGraphics.ts
@@ -943,37 +943,4 @@ export class SmoothGraphics extends Container
 
         super.destroy(options);
     }
-
-    drawStar(x: number, y: number,
-        points: number, radius: number, innerRadius: number, rotation = 0): SmoothGraphics
-    {
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        return this.drawPolygon(new Star(x, y, points, radius, innerRadius, rotation) as Polygon);
-    }
-}
-
-export class Star extends Polygon
-{
-    constructor(x: number, y: number, points: number, radius: number, innerRadius?: number, rotation = 0)
-    {
-        innerRadius = innerRadius || radius / 2;
-
-        const startAngle = (-1 * Math.PI / 2) + rotation;
-        const len = points * 2;
-        const delta = PI_2 / len;
-        const polygon = [];
-
-        for (let i = 0; i < len; i++)
-        {
-            const r = i % 2 ? innerRadius : radius;
-            const angle = (i * delta) + startAngle;
-
-            polygon.push(
-                x + (r * Math.cos(angle)),
-                y + (r * Math.sin(angle))
-            );
-        }
-
-        super(polygon);
-    }
 }


### PR DESCRIPTION
This method has been removed from core Graphics and moved to graphics-extras. It should also be removed here.

As a workaround for users that need `drawStar` (or any extras) I would suggest doing this:

```js
import { SmoothGraphics } from '@pixi/graphics-smooth';
import { Graphics } from '@pixi/graphics';
import '@pixi/graphics-extras';

Object.assign(SmoothGraphics.prototype, {
    drawTorus: Graphics.prototype.drawTorus,
    drawChamferRect: Graphics.prototype.drawChamferRect,
    drawFilletRect: Graphics.prototype.drawFilletRect,
    drawRegularPolygon: Graphics.prototype.drawRegularPolygon,
    drawRoundedPolygon: Graphics.prototype.drawRoundedPolygon,
    drawStar: Graphics.prototype.drawStar,
});
```