### PR TITLE
Make the method call signature match Graphics more closely

### DIFF
--- a/src/SmoothGraphics.ts
+++ b/src/SmoothGraphics.ts
@@ -510,12 +510,12 @@ export class SmoothGraphics extends Container
         return this.drawShape(new Ellipse(x, y, width, height));
     }
 
-    public drawPolygon(...path: Array<number> | Array<Point>): this;
-    public drawPolygon(path: Array<number> | Array<Point> | Polygon): this;
+    public drawPolygon(...path: Array<number> | Array<IPointData>): this;
+    public drawPolygon(path: Array<number> | Array<IPointData> | Polygon): this;
 
     public drawPolygon(...path: any[]): this
     {
-        let points: Array<number> | Array<Point>;
+        let points: Array<number> | Array<IPointData>;
         let closeStroke = true;// !!this._fillStyle;
 
         const poly = path[0] as Polygon;


### PR DESCRIPTION
drawPolygon in Graphics take IPointData and in SmoothGraphics a Point, this makes plug and play replacement harder